### PR TITLE
Fix client key generation in shadow socks

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -2151,7 +2151,7 @@ Inbound.ShadowsocksSettings = class extends Inbound.Settings {
         method = SSMethods.BLAKE3_AES_256_GCM,
         password = '',
         network = 'tcp,udp',
-        shadowsockses = [new Inbound.ShadowsocksSettings.Shadowsocks()],
+        shadowsockses = [new Inbound.ShadowsocksSettings.Shadowsocks(method)],
         ivCheck = false,
     ) {
         super(protocol);

--- a/web/html/modals/inbound_modal.html
+++ b/web/html/modals/inbound_modal.html
@@ -106,7 +106,7 @@
             SSMethodChange() {
                 if (this.inModal.inbound.isSSMultiUser) {
                     if (this.inModal.inbound.settings.shadowsockses.length ==0){
-                        this.inModal.inbound.settings.shadowsockses = [new Inbound.ShadowsocksSettings.Shadowsocks()];
+                        this.inModal.inbound.settings.shadowsockses = [new Inbound.ShadowsocksSettings.Shadowsocks(this.inModal.inbound.settings.method)];
                     }
                     if (!this.inModal.inbound.isSS2022) {
                         this.inModal.inbound.settings.shadowsockses.forEach(client => {


### PR DESCRIPTION
Fix automatic client key generation for ShadowSocks 2022.

Previously, the `ShadowsocksSettings.Shadowsocks` client constructor did not correctly inherit the method from the parent inbound, causing `isSS2022()` to return false and preventing the client key from being generated. This led to SS2022 errors and server reboots.