### PR TITLE
Investigate missing flow switch for xhttp clients

### DIFF
--- a/web/assets/js/model/inbound.js
+++ b/web/assets/js/model/inbound.js
@@ -1200,7 +1200,7 @@ class Inbound extends XrayCommonClass {
 
     //this is used for xtls-rprx-vision
     canEnableTlsFlow() {
-        if (((this.stream.security === 'tls') || (this.stream.security === 'reality')) && (this.network === "tcp")) {
+        if (((this.stream.security === 'tls') || (this.stream.security === 'reality')) && (this.network === "tcp" || this.network === "xhttp")) {
             return this.protocol === Protocols.VLESS;
         }
         return false;

--- a/web/assets/js/model/outbound.js
+++ b/web/assets/js/model/outbound.js
@@ -608,7 +608,7 @@ class Outbound extends CommonClass {
 
     //this is used for xtls-rprx-vision
     canEnableTlsFlow() {
-        if ((this.stream.security != 'none') && (this.stream.network === "tcp")) {
+        if ((this.stream.security != 'none') && (this.stream.network === "tcp" || this.stream.network === "xhttp")) {
             return this.protocol === Protocols.VLESS;
         }
         return false;


### PR DESCRIPTION
Enable flow control for xhttp protocol clients by extending `canEnableTlsFlow()` to include xhttp network type.

---
<a href="https://cursor.com/background-agent?bcId=bc-17d1d62d-5238-4506-aa8f-8c28f28ad2d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17d1d62d-5238-4506-aa8f-8c28f28ad2d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

